### PR TITLE
Set up deployment configurations for OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+HotelBooker/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/HotelBooking/Models/utils.py
+++ b/HotelBooking/Models/utils.py
@@ -1,8 +1,17 @@
+import sys
+import os
 from sqlmodel import create_engine
 
 
-DATABASE_ADDRESS = "sqlite:///HotelBooking/Database/Hotel.db"
+def get_database_address():
+    if getattr(sys, 'frozen', False):
+        db_address = os.path.join(
+            os.path.dirname(sys.executable), 'DB/Hotel.db')
+    else:
+        db_address = "HotelBooking/Database/Hotel.db"
+    return db_address
 
 
 def get_engine():
-    return create_engine(DATABASE_ADDRESS)
+    db_address = get_database_address()
+    return create_engine(f"sqlite:///{db_address}")

--- a/HotelBooking/Models/utils.py
+++ b/HotelBooking/Models/utils.py
@@ -4,7 +4,12 @@ from sqlmodel import create_engine
 
 
 def get_database_address():
+    """
+    Database addresses are different depending on whether the project
+    is being executed as a script file or as a frozen system executable.
+    """
     if getattr(sys, 'frozen', False):
+        # is frozen as executable
         db_address = os.path.join(
             os.path.dirname(sys.executable), 'DB/Hotel.db')
     else:

--- a/HotelBooking/README.md
+++ b/HotelBooking/README.md
@@ -11,3 +11,12 @@
 - The database being used is sqlite, and support for sqlite is built-in in Python, and it should have no problem running on MacOS. If you run into errors, first check if your system has sqlite.
 - If the database is corrupt, run `./reset-db.sh` to recreate the database and tables with initial data.
   - Note that the command in the reset script is Linux based and does **NOT** work in windows. You need to find windows equivalent commands for sqlite if you are using windows power-shell.
+
+## Deployment
+
+- The deployment framework is `PyInstaller`
+- Deployment configurations for Windows is currently missing
+- For MacOS deployment:
+  - Easiest way of setting up is by running `brew install pyinstaller`
+  - After pyinstaller is installed, run `./deploy.sh -e osx`
+  - This will generate the one file MacOS binary inside HotelBooker/

--- a/HotelBooking/deploy.sh
+++ b/HotelBooking/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# using while in case we add more flags in the future
+while getopts e: flag
+do
+  case "${flag}" in
+    e) env=${OPTARG};;
+  esac
+done
+
+if [ -z "$env" ]; then
+  echo "Empty deployment environment, use -e <OS> to generate executable"
+elif [ $env == "osx" ]; then
+  echo "Deploying for Mac OSX"
+  pyinstaller --onefile \
+    --collect-all pyfiglet \
+    main.py
+  mkdir -p HotelBooker/DB
+  mv dist/main HotelBooker/HotelBooker
+  cp Database/Hotel.db HotelBooker/DB/
+elif [ $env == "windows" ]; then
+  echo "Deploying for Windows"
+else
+  echo "Not valid environment, pick between 'osx' and 'windows'"
+fi

--- a/HotelBooking/main.py
+++ b/HotelBooking/main.py
@@ -1,4 +1,3 @@
-import os
 from HotelBooking.Views.authentication_view import AuthenticationView
 from HotelBooking.Views.utils import big_print
 

--- a/HotelBooking/main.py
+++ b/HotelBooking/main.py
@@ -1,3 +1,4 @@
+import os
 from HotelBooking.Views.authentication_view import AuthenticationView
 from HotelBooking.Views.utils import big_print
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@
 A hotel booking system that allows customers to book their own rooms in a simple, easy to use process. The software also provides management with tools that automate common tasks such as checking in customers and generating reports on demand showing hotel capacity and customer booking details.
 
 ## 📌 Diagrams
+
 - Class Diagram [[png]](Diagrams/ClassDiagram/Class%20Diagram.drawio.png)&nbsp;[[draw.io]](Diagrams/ClassDiagram/Class%20Diagram.drawio)
 - ER Diagram [[png]](Diagrams/ERDiagram/ERDiagram.drawio.png)&nbsp;[[draw.io]](Diagrams/ERDiagram/ERDiagram.drawio)
 - System Architecture Diagram [[png]](Diagrams/SystemArchitecture/System%20Architecture.drawio.png)&nbsp;[[draw.io]](Diagrams/SystemArchitecture/System%20Architecture.drawio)
-- Sequence Diagrams 
+- Sequence Diagrams
   - Authentication [[png]](Diagrams/Sequence/Authentication.drawio.png)&nbsp;[[draw.io]](Diagrams/Sequence/Authentication.drawio)
   - Customer Modify Reservation [[png]](Diagrams/Sequence/CustomerModifyReservation.drawio.png)&nbsp;[[draw.io]](Diagrams/Sequence/CustomerModifyReservation.drawio)
   - End Customer Stay [[png]](Diagrams/Sequence/EndCustomerStay.drawio.png)&nbsp;[[draw.io]](Diagrams/Sequence/EndCustomerStay.drawio)
-- Use Case Diagrams 
+- Use Case Diagrams
   - Login Registration [[png]](Diagrams/UseCase/LoginRegistration.drawio.png)&nbsp;[[draw.io]](Diagrams/UseCase/LoginRegistration.drawio)
   - Hotel Booker [[png]](Diagrams/UseCase/HotelBooker.drawio.png)&nbsp;[[draw.io]](Diagrams/UseCase/HotelBooker.drawio)
   - Hotel Manager [[png]](Diagrams/UseCase/HotelManager.drawio.png)&nbsp;[[draw.io]](Diagrams/UseCase/HotelManager.drawio)
@@ -35,4 +36,9 @@ cd HotelBooking
 ```sh
 ./run.sh
 ```
+
 [More Information](HotelBooking#readme)
+
+### 3. **Deployment**
+
+See `README` inside `HotelBooking/` for details

--- a/README.md
+++ b/README.md
@@ -38,7 +38,3 @@ cd HotelBooking
 ```
 
 [More Information](HotelBooking#readme)
-
-### 3. **Deployment**
-
-See `README` inside `HotelBooking/` for details


### PR DESCRIPTION
While PyInstaller supports cross-platform deployment of python projects into system executable binaries, it does not support building `exe` cross-platform, meaning on MacOS you cannot build a Windows executable. This PR includes deployment setup and instructions for macOS ONLY.